### PR TITLE
Add bootable checkbox to bulk editor and make it work

### DIFF
--- a/systems/admin.py
+++ b/systems/admin.py
@@ -392,33 +392,37 @@ class SystemAdmin(admin.ModelAdmin):
                       )
                   fieldsUpdated=True
             # Handle set_bootable: mark the NIC matching each system's prov_interface as bootable
+            bootable_updated = 0
             if 'update_set_bootable' in request.POST:
               if not form.cleaned_data.get('set_bootable'):
-                self.message_user(request, "Set bootable interface was selected but not checked.")
-                return render(
-                   request,
-                   'admin/system_bulk_change_form.html',
-                    context={
-                        **self.admin_site.each_context(request),
-                        'adminform': form,
-                        'items': queryset,
-                        'media': self.media,
-                        'opts': self.model._meta,
-                    }
-                )
-              bootable_updated = 0
-              for item in queryset.all():
-                  prov_iface = item.prov_interface.strip() if item.prov_interface else ''
-                  if not prov_iface:
-                      continue
+                # if the checkbox is not checked, update bootable to false for all nics on the selected systems.
+                for item in queryset.all():
                   nics = NetworkInterface.objects.filter(system=item)
                   for nic in nics:
-                      if nic.name == prov_iface:
-                          nic.bootable = True
-                          bootable_updated += 1
-                      else:
-                          nic.bootable = False
-                      nic.save()
+                    nic.bootable = False
+                    nic.save()
+                  bootable_updated += 1
+                self.message_user(request, f"Bootable NIC cleared on {queryset.count()} system(s).")
+                fieldsUpdated = True 
+              else:
+                for item in queryset.all():
+                    prov_iface = item.prov_interface.strip() if item.prov_interface else ''
+                    if not prov_iface:
+                      # no prov_interface specified for this system, enable all interfaces.
+                      nics = NetworkInterface.objects.filter(system=item)
+                      for nic in nics:
+                        nic.bootable = True
+                        nic.save()
+                      bootable_updated += 1
+                    else:
+                      nics = NetworkInterface.objects.filter(system=item)
+                      for nic in nics:
+                          if nic.name == prov_iface:
+                              nic.bootable = True
+                              bootable_updated += 1
+                          else:
+                              nic.bootable = False
+                          nic.save()
               self.message_user(request, f"Bootable NIC set on {bootable_updated} system(s).")
               fieldsUpdated = True
 

--- a/systems/admin.py
+++ b/systems/admin.py
@@ -312,13 +312,16 @@ class SystemAdmin(admin.ModelAdmin):
   def bulk_update(self, request, queryset):
     # fields to allow multiple updates to.
     fields = ['systemimage','systemmodel','stateful','prov_interface','initial_mods', 'systemgroups', 'disks']
+    class BulkUpdateForm(self.get_form(request)):
+        set_bootable = forms.BooleanField(required=False, label="Set bootable interface")
+
     def remove_fields(form):
         for field in list(form.base_fields.keys()):
-            if field  not in fields:
+            if field not in fields and field != 'set_bootable':
                 del form.base_fields[field]
         return form
 
-    form_class = remove_fields(self.get_form(request))
+    form_class = remove_fields(BulkUpdateForm)
 
     if request.method == 'POST':
         form = form_class()
@@ -388,6 +391,37 @@ class SystemAdmin(admin.ModelAdmin):
                           }
                       )
                   fieldsUpdated=True
+            # Handle set_bootable: mark the NIC matching each system's prov_interface as bootable
+            if 'update_set_bootable' in request.POST:
+              if not form.cleaned_data.get('set_bootable'):
+                self.message_user(request, "Set bootable interface was selected but not checked.")
+                return render(
+                   request,
+                   'admin/system_bulk_change_form.html',
+                    context={
+                        **self.admin_site.each_context(request),
+                        'adminform': form,
+                        'items': queryset,
+                        'media': self.media,
+                        'opts': self.model._meta,
+                    }
+                )
+              bootable_updated = 0
+              for item in queryset.all():
+                  prov_iface = item.prov_interface.strip() if item.prov_interface else ''
+                  if not prov_iface:
+                      continue
+                  nics = NetworkInterface.objects.filter(system=item)
+                  for nic in nics:
+                      if nic.name == prov_iface:
+                          nic.bootable = True
+                          bootable_updated += 1
+                      else:
+                          nic.bootable = False
+                      nic.save()
+              self.message_user(request, f"Bootable NIC set on {bootable_updated} system(s).")
+              fieldsUpdated = True
+
             if fieldsUpdated is False:
               self.message_user(request, "No fields selected to update.")
               return render(


### PR DESCRIPTION
## Problem

The bulk system editor had no way to set the `bootable` flag on network interfaces. Systems need at least one bootable NIC to PXE boot, but the bulk editor only supported updating fields on the `System` model itself — `bootable` lives on the `NetworkInterface` model, so it was never exposed.

## Solution

Three changes to `systems/admin.py`:

1. **Added `set_bootable` checkbox** — A `BooleanField` on `BulkUpdateForm` renders in the bulk editor template.
2. **Preserved from field removal** — `remove_fields()` now keeps `set_bootable` so it appears alongside the other bulk-edit fields.
3. **Added handler logic** — When checked, the POST handler:
   - Looks up each system's `prov_interface` value
   - Finds the matching `NetworkInterface` by name and sets `bootable=True`
   - Sets `bootable=False` on all other NICs for that system (only one bootable NIC per system)
   - Reports how many systems were updated via `message_user`

## Files changed

- `systems/admin.py`
